### PR TITLE
Potential fix for code scanning alert no. 10: Shell command built from environment values

### DIFF
--- a/packages/cache/src/internal/tar.ts
+++ b/packages/cache/src/internal/tar.ts
@@ -149,16 +149,16 @@ async function getCommands(
     IS_WINDOWS
 
   if (BSD_TAR_ZSTD && type !== 'create') {
-    args = [[...compressionArgs].join(' '), [...tarArgs].join(' ')]
+    args = [compressionArgs, tarArgs]
   } else {
-    args = [[...tarArgs].join(' '), [...compressionArgs].join(' ')]
+    args = [tarArgs, compressionArgs]
   }
 
   if (BSD_TAR_ZSTD) {
-    return args
+    return args.flat()
   }
 
-  return [args.join(' ')]
+  return args.flat()
 }
 
 function getWorkingDirectory(): string {
@@ -248,13 +248,14 @@ async function getCompressionProgram(
 async function execCommands(commands: string[], cwd?: string): Promise<void> {
   for (const command of commands) {
     try {
-      await exec(command, undefined, {
+      const [tool, ...args] = command
+      await exec(tool, args, {
         cwd,
         env: {...(process.env as object), MSYS: 'winsymlinks:nativestrict'}
       })
     } catch (error) {
       throw new Error(
-        `${command.split(' ')[0]} failed with error: ${error?.message}`
+        `${command[0]} failed with error: ${error?.message}`
       )
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/whartondylan/toolkit/security/code-scanning/10](https://github.com/whartondylan/toolkit/security/code-scanning/10)

The issue can be resolved by avoiding dynamic shell command construction altogether. Instead of concatenating strings to form commands, we should construct the command and its arguments separately and pass them to a method that does not interpret the command through a shell. The `@actions/exec` library provides `exec` with arguments passed as an array, which is a safer alternative.

To fix the issue:
1. Modify `getCommands` to return arrays of command arguments instead of concatenated strings.
2. Update `execCommands` to execute commands by passing the command and its arguments separately to `exec`.

This ensures that the shell does not interpret any special characters in the arguments, preventing command injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
