### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cache-windows-test.yml
+++ b/.github/workflows/cache-windows-test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: cache-windows-bsd-unit-tests
 on:
   push:
@@ -8,7 +10,6 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/whartondylan/toolkit/security/code-scanning/1](https://github.com/whartondylan/toolkit/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow. Since the workflow does not seem to require write permissions, we can restrict permissions to `contents: read`, which is the minimal necessary permission to access repository contents. This change ensures that the workflow's `GITHUB_TOKEN` has only the required permissions and does not inherit unnecessary permissions from the repository or organization.

The fix involves adding the following block at the root level of the workflow, under the `name` field:

```yaml
permissions:
  contents: read
```

This ensures that all jobs in the workflow, including the `Build` job, will use these reduced permissions unless overridden at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
